### PR TITLE
[WIP] Add SQL linting support

### DIFF
--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -15,6 +15,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>11.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/parser/src/main/java/com/facebook/coresql/lint/LintingVisitor.java
+++ b/parser/src/main/java/com/facebook/coresql/lint/LintingVisitor.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.coresql.lint;
+
+import com.facebook.coresql.parser.AstNode;
+import com.facebook.coresql.parser.SqlParserDefaultVisitor;
+import com.facebook.coresql.warning.WarningCode;
+import com.facebook.coresql.warning.WarningCollector;
+
+public abstract class LintingVisitor
+        extends SqlParserDefaultVisitor
+{
+    private final WarningCollector warningCollector;
+
+    public LintingVisitor(WarningCollector collector)
+    {
+        this.warningCollector = collector;
+    }
+
+    public void addWarningToCollector(WarningCode code, String warningMessage, AstNode node)
+    {
+        warningCollector.add(code, warningMessage, node);
+    }
+
+    /**
+     * Entry point to recursive visiting routine. We recurse, add any warnings to the current collector, then return.
+     *
+     * @param node The root of the AST we're validating
+     */
+    public void lint(AstNode node)
+    {
+        node.jjtAccept(this, null);
+    }
+
+    public WarningCollector getWarningCollector()
+    {
+        return warningCollector;
+    }
+}

--- a/parser/src/main/java/com/facebook/coresql/lint/MixedAndOr.java
+++ b/parser/src/main/java/com/facebook/coresql/lint/MixedAndOr.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.coresql.lint;
+
+import com.facebook.coresql.parser.AndExpression;
+import com.facebook.coresql.parser.OrExpression;
+import com.facebook.coresql.warning.WarningCollector;
+
+import static com.facebook.coresql.parser.SqlParserTreeConstants.JJTANDEXPRESSION;
+import static com.facebook.coresql.parser.SqlParserTreeConstants.JJTOREXPRESSION;
+import static com.facebook.coresql.warning.StandardWarningCode.MIXING_AND_OR_WITHOUT_PARENTHESES;
+
+/**
+ * A visitor that validates an AST built from an SQL string. Right now, it validates
+ * a single clause: don't mix AND and OR without parentheses.
+ */
+public class MixedAndOr
+        extends LintingVisitor
+{
+    private static final String WARNING_MESSAGE = "Mixing AND and OR without parentheses.";
+
+    public MixedAndOr(WarningCollector collector)
+    {
+        super(collector);
+    }
+
+    @Override
+    public void visit(OrExpression node, Void data)
+    {
+        if (node.jjtGetParent().getId() == JJTANDEXPRESSION) {
+            super.addWarningToCollector(MIXING_AND_OR_WITHOUT_PARENTHESES.getWarningCode(),
+                    WARNING_MESSAGE,
+                    node);
+        }
+        defaultVisit(node, data);
+    }
+
+    @Override
+    public void visit(AndExpression node, Void data)
+    {
+        if (node.jjtGetParent().getId() == JJTOREXPRESSION) {
+            super.addWarningToCollector(MIXING_AND_OR_WITHOUT_PARENTHESES.getWarningCode(),
+                    WARNING_MESSAGE,
+                    node);
+        }
+        defaultVisit(node, data);
+    }
+}

--- a/parser/src/main/java/com/facebook/coresql/parser/AstNode.java
+++ b/parser/src/main/java/com/facebook/coresql/parser/AstNode.java
@@ -75,15 +75,15 @@ public class AstNode
         return null;
     }
 
-    public String GetCoordinates()
+    public Location getLocation()
     {
-        return beginToken.beginLine + ":" + beginToken.beginColumn + "-" + endToken.endLine + ":" + endToken.endColumn;
+        return new Location(beginToken.beginLine, beginToken.beginColumn, endToken.endLine, endToken.endColumn);
     }
 
     @Override
     public String toString(String prefix)
     {
-        return super.toString(prefix) + " (" + GetCoordinates() + ")" +
+        return super.toString(prefix) + " (" + getLocation().toString() + ")" +
                 (NumChildren() == 0 ? " (" + beginToken.image + ")" : "");
     }
 }

--- a/parser/src/main/java/com/facebook/coresql/parser/Location.java
+++ b/parser/src/main/java/com/facebook/coresql/parser/Location.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.coresql.parser;
+
+import static java.lang.String.format;
+
+public class Location
+{
+    private final int beginLine;
+    private final int beginColumn;
+    private final int endLine;
+    private final int endColumn;
+
+    public Location(int beginLine, int beginColumn, int endLine, int endColumn)
+    {
+        this.beginLine = beginLine;
+        this.beginColumn = beginColumn;
+        this.endLine = endLine;
+        this.endColumn = endColumn;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("%d:%d-%d:%d", beginLine, beginColumn, endLine, endColumn);
+    }
+}

--- a/parser/src/main/java/com/facebook/coresql/warning/CoreSqlWarning.java
+++ b/parser/src/main/java/com/facebook/coresql/warning/CoreSqlWarning.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.coresql.warning;
+
+import com.facebook.coresql.parser.Location;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public final class CoreSqlWarning
+{
+    private final WarningCode warningCode;
+    private final String message;
+    private final Location location;
+
+    public CoreSqlWarning(WarningCode warningCode, String message,
+            int beginLine,
+            int beginColumn,
+            int endLine,
+            int endColumn)
+    {
+        this.warningCode = requireNonNull(warningCode, "Warning code is null");
+        this.message = requireNonNull(message, "Warning message is null");
+        this.location = new Location(beginLine, beginColumn, endLine, endColumn);
+    }
+
+    public WarningCode getWarningCode()
+    {
+        return warningCode;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Warning@%s message: %s [%s]", location, message, warningCode);
+    }
+}

--- a/parser/src/main/java/com/facebook/coresql/warning/DefaultWarningCollector.java
+++ b/parser/src/main/java/com/facebook/coresql/warning/DefaultWarningCollector.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.coresql.warning;
+
+import com.facebook.coresql.parser.AstNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class DefaultWarningCollector
+        implements WarningCollector
+{
+    private final Multimap<WarningCode, CoreSqlWarning> warnings = LinkedListMultimap.create();
+    private final WarningCollectorConfig config;
+
+    public DefaultWarningCollector(WarningCollectorConfig config)
+    {
+        this.config = requireNonNull(config, "config is null");
+    }
+
+    @Override
+    public void add(WarningCode code, String warningMessage, AstNode node)
+    {
+        requireNonNull(code, "warning code is null");
+        requireNonNull(warningMessage, "warning message is null");
+        requireNonNull(node, "node is null");
+        addWarningIfNumWarningsLessThanConfig(new CoreSqlWarning(code,
+                warningMessage,
+                node.beginToken.beginLine,
+                node.beginToken.beginColumn,
+                node.beginToken.endLine,
+                node.beginToken.endColumn));
+    }
+
+    @Override
+    public List<CoreSqlWarning> getAllWarnings()
+    {
+        return ImmutableList.copyOf(warnings.values());
+    }
+
+    @Override
+    public void clearWarnings()
+    {
+        warnings.clear();
+    }
+
+    private void addWarningIfNumWarningsLessThanConfig(CoreSqlWarning coreSqlWarning)
+    {
+        if (warnings.size() < config.getMaxWarnings()) {
+            warnings.put(coreSqlWarning.getWarningCode(), coreSqlWarning);
+        }
+    }
+}

--- a/parser/src/main/java/com/facebook/coresql/warning/StandardWarningCode.java
+++ b/parser/src/main/java/com/facebook/coresql/warning/StandardWarningCode.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.coresql.warning;
+
+public enum StandardWarningCode
+{
+    MIXING_AND_OR_WITHOUT_PARENTHESES(0x0000_0001);
+
+    private final WarningCode warningCode;
+
+    StandardWarningCode(int code)
+    {
+        warningCode = new WarningCode(code, name());
+    }
+
+    public WarningCode getWarningCode()
+    {
+        return warningCode;
+    }
+}

--- a/parser/src/main/java/com/facebook/coresql/warning/WarningCode.java
+++ b/parser/src/main/java/com/facebook/coresql/warning/WarningCode.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.coresql.warning;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class WarningCode
+{
+    private final int code;
+    private final String name;
+
+    public WarningCode(int code, String name)
+    {
+        this.code = code;
+        this.name = requireNonNull(name, "name is null");
+    }
+
+    public int getCode()
+    {
+        return code;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public String toString()
+    {
+        return name + ", " + code;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        WarningCode that = (WarningCode) obj;
+        return this.code == that.code && Objects.equals(this.name, that.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(code, name);
+    }
+}

--- a/parser/src/main/java/com/facebook/coresql/warning/WarningCollector.java
+++ b/parser/src/main/java/com/facebook/coresql/warning/WarningCollector.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.coresql.warning;
+
+import com.facebook.coresql.parser.AstNode;
+
+import java.util.List;
+
+public interface WarningCollector
+{
+    void add(WarningCode code, String warningMessage, AstNode node);
+
+    List<CoreSqlWarning> getAllWarnings();
+
+    void clearWarnings();
+}

--- a/parser/src/main/java/com/facebook/coresql/warning/WarningCollectorConfig.java
+++ b/parser/src/main/java/com/facebook/coresql/warning/WarningCollectorConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.coresql.warning;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class WarningCollectorConfig
+{
+    private int maxWarnings = Integer.MAX_VALUE;
+
+    public WarningCollectorConfig setMaxWarnings(int maxWarnings)
+    {
+        checkArgument(maxWarnings >= 0, "maxWarnings must be >= 0");
+        this.maxWarnings = maxWarnings;
+        return this;
+    }
+
+    public int getMaxWarnings()
+    {
+        return maxWarnings;
+    }
+}

--- a/parser/src/test/java/com/facebook/coresql/lint/TestMixedAndOr.java
+++ b/parser/src/test/java/com/facebook/coresql/lint/TestMixedAndOr.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.coresql.lint;
+
+import com.facebook.coresql.parser.AstNode;
+import com.facebook.coresql.warning.DefaultWarningCollector;
+import com.facebook.coresql.warning.WarningCollectorConfig;
+import org.testng.annotations.Test;
+
+import static com.facebook.coresql.parser.ParserHelper.parseStatement;
+import static com.facebook.coresql.warning.StandardWarningCode.MIXING_AND_OR_WITHOUT_PARENTHESES;
+import static org.testng.Assert.assertEquals;
+
+public class TestMixedAndOr
+{
+    private static final LintingVisitor LINTING_VISITOR = new MixedAndOr(new DefaultWarningCollector(new WarningCollectorConfig().setMaxWarnings(1)));
+    private static final String[] NON_WARNING_SQL_STRINGS = new String[] {
+            "SELECT (true or false) and false;",
+            "SELECT true or false or true;",
+            "SELECT true and false and false;",
+            "SELECT a FROM T WHERE a.id = 2 or (a.id = 3 and a.age = 73);",
+            "SELECT a FROM T WHERE (a.id = 2 or a.id = 3) and (a.age = 73 or a.age = 100);",
+            "SELECT * from Evaluation e JOIN Value v ON e.CaseNum = v.CaseNum\n" +
+                    "    AND e.FileNum = v.FileNum AND e.ActivityNum = v.ActivityNum;",
+            "use a.b;",
+            " SELECT 1;",
+            "SELECT a FROM T;",
+            "SELECT a FROM T WHERE p1 > p2;",
+            "SELECT a, b, c FROM T WHERE c1 < c2 and c3 < c4;",
+            "SELECT CASE a WHEN IN ( 1 ) THEN b ELSE c END AS x, b, c FROM T WHERE c1 < c2 and c3 < c4;",
+            "SELECT T.* FROM T JOIN W ON T.x = W.x;",
+            "SELECT NULL;",
+            "SELECT ARRAY[x] FROM T;",
+            "SELECT TRANSFORM(ARRAY[x], x -> x + 2) AS arra FROM T;",
+            "CREATE TABLE T AS SELECT TRANSFORM(ARRAY[x], x -> x + 2) AS arra FROM T;",
+            "INSERT INTO T SELECT TRANSFORM(ARRAY[x], x -> x + 2) AS arra FROM T;",
+            "SELECT ROW_NUMBER() OVER(PARTITION BY x) FROM T;",
+            "SELECT x, SUM(y) OVER (PARTITION BY y ORDER BY 1) AS min\n" +
+                    "FROM (values ('b',10), ('a', 10)) AS T(x, y)\n;",
+            "SELECT\n" +
+                    " CAST(MAP() AS map<bigint,array<boolean>>) AS \"bool_tensor_features\";",
+            "SELECT f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f(f())))))))))))))))))))))))))))));",
+            "SELECT abs, 2 as abs;",
+    };
+
+    private static final String[] WARNING_SQL_STRINGS = new String[] {
+            "SELECT true or false and false;",
+            "SELECT a FROM T WHERE a.id = 2 or a.id = 3 and a.age = 73;",
+            "SELECT a FROM T WHERE (a.id = 2 or a.id = 3) and a.age = 73 or a.age = 100;"
+    };
+
+    private static void assertHasMixedAndOrWarnings(String statement, int expectedNumWarnings)
+    {
+        AstNode ast = parseStatement(statement);
+        LINTING_VISITOR.lint(ast);
+        assertEquals(LINTING_VISITOR.getWarningCollector().getAllWarnings().size(), expectedNumWarnings);
+        LINTING_VISITOR.getWarningCollector().getAllWarnings().forEach(x ->
+                assertEquals(x.getWarningCode(), MIXING_AND_OR_WITHOUT_PARENTHESES.getWarningCode()));
+    }
+
+    @Test
+    public void testDoesntThrowsMixedAndOrWarning()
+    {
+        LINTING_VISITOR.getWarningCollector().clearWarnings();
+        for (String sql : NON_WARNING_SQL_STRINGS) {
+            assertHasMixedAndOrWarnings(sql, 0);
+        }
+    }
+
+    @Test
+    public void testThrowsMixedAndOrWarning()
+    {
+        LINTING_VISITOR.getWarningCollector().clearWarnings();
+        for (String sql : WARNING_SQL_STRINGS) {
+            assertHasMixedAndOrWarnings(sql, 1);
+        }
+    }
+}

--- a/parser/src/test/java/com/facebook/coresql/parser/TestSqlParser.java
+++ b/parser/src/test/java/com/facebook/coresql/parser/TestSqlParser.java
@@ -22,7 +22,7 @@ import static org.testng.Assert.assertNotNull;
 
 public class TestSqlParser
 {
-    private static final String[] testSqlTeststrings = new String[] {
+    private static final String[] TEST_SQL_TESTSTRINGS = new String[] {
             "use a.b;",
             " SELECT 1;",
             "SELECT a FROM T;",
@@ -52,7 +52,7 @@ public class TestSqlParser
     @Test
     public void smokeTest()
     {
-        for (String sql : testSqlTeststrings) {
+        for (String sql : TEST_SQL_TESTSTRINGS) {
             assertNotNull(parse(sql));
         }
     }
@@ -60,7 +60,7 @@ public class TestSqlParser
     @Test
     public void parseUnparseTest()
     {
-        for (String sql : testSqlTeststrings) {
+        for (String sql : TEST_SQL_TESTSTRINGS) {
             AstNode ast = parse(sql);
             assertNotNull(ast);
             assertEquals(sql.trim(), unparse(ast).trim());

--- a/parser/src/test/java/com/facebook/coresql/warning/TestWarningCollector.java
+++ b/parser/src/test/java/com/facebook/coresql/warning/TestWarningCollector.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.coresql.warning;
+
+import com.facebook.coresql.parser.AstNode;
+import org.testng.annotations.Test;
+
+import static com.facebook.coresql.parser.ParserHelper.parseStatement;
+import static org.testng.Assert.assertEquals;
+
+public class TestWarningCollector
+{
+    private static final AstNode AST_NODE = parseStatement("SELECT true or false and false;");
+    private static final WarningCollector COLLECTOR = new DefaultWarningCollector(new WarningCollectorConfig().setMaxWarnings(1));
+
+    private static void assertCollectorHasOneWarning()
+    {
+        assertEquals(COLLECTOR.getAllWarnings().size(), 1);
+    }
+
+    @Test
+    public void addWarningTest()
+    {
+        COLLECTOR.add(new WarningCode(0, "test code"), "msg", AST_NODE);
+        assertCollectorHasOneWarning();
+    }
+
+    @Test
+    public void testWarningsExceedMaxInConfig()
+    {
+        COLLECTOR.add(new WarningCode(0, "test code"), "msg", AST_NODE);
+        COLLECTOR.add(new WarningCode(0, "test code"), "msg", AST_NODE);
+        assertCollectorHasOneWarning();
+    }
+}


### PR DESCRIPTION
**Overview**
Added a set of objects for managing warnings and/or errors that arise when building AST's from SQL expressions. The only implemented warning (so far) is when an SQL expression mixes AND and OR without parentheses. Warnings are collected by traversing an AST with LintVisitor and adding warning to LintVisitor's WarningCollector if certain conditions are met.

**Specific Changes**

1. Added lint package (LintVisitor and TestLintVisitor)
2. Added warning package (CoreSqlWarning, WarningCollector, WarningCollectorTest, ...)
3. Added multiple test SQL strings
4. Changed (almost all) signatures of AstNode to be camelCase

**Potential Next Steps**

1. Remove WarningCollector state from LintVisitor
2. Re-factor code for specific patterns (fail fast, loose coupling, ...)
3. Change _all_ signatures of AstNode to be camelCase
4. Add more test files for the Warning classes
5. Add more test cases to existing test files