### PR TITLE
Move linter code into top-level package

### DIFF
--- a/linter/pom.xml
+++ b/linter/pom.xml
@@ -8,8 +8,8 @@
         <version>0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>presto-coresql-parser</artifactId>
-    <name>presto-coresql-parser</name>
+    <artifactId>presto-coresql-linter</artifactId>
+    <name>presto-coresql-linter</name>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
@@ -30,49 +30,21 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-coresql-parser</artifactId>
+            <version>0.2-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
-                <executions>
-                    <execution>
-                        <id>Build-parser</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <executable>./prepare-javacc-grammar.sh</executable>
-                    <basedir>grammar</basedir>
-                    <workingDirectory>grammar</workingDirectory>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.javacc.plugin</groupId>
-                <artifactId>javacc-maven-plugin</artifactId>
-                <version>3.0.2</version>
-                <executions>
-                    <execution>
-                        <id>jcc7jcc</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>jjtree-javacc</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirectory>target/generated-sources/javacc</sourceDirectory>
-                            <outputLanguage>java</outputLanguage>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -196,19 +168,6 @@
 
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.javacc.plugin</groupId>
-                    <artifactId>javacc-maven-plugin</artifactId>
-                    <dependencies>
-                        <dependency>
-                            <groupId>net.java.dev.javacc</groupId>
-                            <artifactId>javacc</artifactId>
-                            <version>7.0.10</version>
-                            <scope>runtime</scope>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-
                 <plugin>
                     <groupId>org.gaul</groupId>
                     <artifactId>modernizer-maven-plugin</artifactId>

--- a/linter/src/main/java/com/facebook/coresql/linter/lint/LintingVisitor.java
+++ b/linter/src/main/java/com/facebook/coresql/linter/lint/LintingVisitor.java
@@ -12,12 +12,12 @@
  * limitations under the License.
  */
 
-package com.facebook.coresql.lint;
+package com.facebook.coresql.linter.lint;
 
+import com.facebook.coresql.linter.warning.WarningCode;
+import com.facebook.coresql.linter.warning.WarningCollector;
 import com.facebook.coresql.parser.AstNode;
 import com.facebook.coresql.parser.SqlParserDefaultVisitor;
-import com.facebook.coresql.warning.WarningCode;
-import com.facebook.coresql.warning.WarningCollector;
 
 public abstract class LintingVisitor
         extends SqlParserDefaultVisitor

--- a/linter/src/main/java/com/facebook/coresql/linter/lint/MixedAndOr.java
+++ b/linter/src/main/java/com/facebook/coresql/linter/lint/MixedAndOr.java
@@ -12,15 +12,15 @@
  * limitations under the License.
  */
 
-package com.facebook.coresql.lint;
+package com.facebook.coresql.linter.lint;
 
+import com.facebook.coresql.linter.warning.WarningCollector;
 import com.facebook.coresql.parser.AndExpression;
 import com.facebook.coresql.parser.OrExpression;
-import com.facebook.coresql.warning.WarningCollector;
 
+import static com.facebook.coresql.linter.warning.StandardWarningCode.MIXING_AND_OR_WITHOUT_PARENTHESES;
 import static com.facebook.coresql.parser.SqlParserTreeConstants.JJTANDEXPRESSION;
 import static com.facebook.coresql.parser.SqlParserTreeConstants.JJTOREXPRESSION;
-import static com.facebook.coresql.warning.StandardWarningCode.MIXING_AND_OR_WITHOUT_PARENTHESES;
 
 /**
  * A visitor that validates an AST built from an SQL string. Right now, it validates

--- a/linter/src/main/java/com/facebook/coresql/linter/warning/CoreSqlWarning.java
+++ b/linter/src/main/java/com/facebook/coresql/linter/warning/CoreSqlWarning.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package com.facebook.coresql.warning;
+package com.facebook.coresql.linter.warning;
 
 import com.facebook.coresql.parser.Location;
 

--- a/linter/src/main/java/com/facebook/coresql/linter/warning/DefaultWarningCollector.java
+++ b/linter/src/main/java/com/facebook/coresql/linter/warning/DefaultWarningCollector.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package com.facebook.coresql.warning;
+package com.facebook.coresql.linter.warning;
 
 import com.facebook.coresql.parser.AstNode;
 import com.google.common.collect.ImmutableList;

--- a/linter/src/main/java/com/facebook/coresql/linter/warning/StandardWarningCode.java
+++ b/linter/src/main/java/com/facebook/coresql/linter/warning/StandardWarningCode.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package com.facebook.coresql.warning;
+package com.facebook.coresql.linter.warning;
 
 public enum StandardWarningCode
 {

--- a/linter/src/main/java/com/facebook/coresql/linter/warning/WarningCode.java
+++ b/linter/src/main/java/com/facebook/coresql/linter/warning/WarningCode.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package com.facebook.coresql.warning;
+package com.facebook.coresql.linter.warning;
 
 import java.util.Objects;
 

--- a/linter/src/main/java/com/facebook/coresql/linter/warning/WarningCollector.java
+++ b/linter/src/main/java/com/facebook/coresql/linter/warning/WarningCollector.java
@@ -12,23 +12,17 @@
  * limitations under the License.
  */
 
-package com.facebook.coresql.warning;
+package com.facebook.coresql.linter.warning;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import com.facebook.coresql.parser.AstNode;
 
-public class WarningCollectorConfig
+import java.util.List;
+
+public interface WarningCollector
 {
-    private int maxWarnings = Integer.MAX_VALUE;
+    void add(WarningCode code, String warningMessage, AstNode node);
 
-    public WarningCollectorConfig setMaxWarnings(int maxWarnings)
-    {
-        checkArgument(maxWarnings >= 0, "maxWarnings must be >= 0");
-        this.maxWarnings = maxWarnings;
-        return this;
-    }
+    List<CoreSqlWarning> getAllWarnings();
 
-    public int getMaxWarnings()
-    {
-        return maxWarnings;
-    }
+    void clearWarnings();
 }

--- a/linter/src/main/java/com/facebook/coresql/linter/warning/WarningCollectorConfig.java
+++ b/linter/src/main/java/com/facebook/coresql/linter/warning/WarningCollectorConfig.java
@@ -12,17 +12,23 @@
  * limitations under the License.
  */
 
-package com.facebook.coresql.warning;
+package com.facebook.coresql.linter.warning;
 
-import com.facebook.coresql.parser.AstNode;
+import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.List;
-
-public interface WarningCollector
+public class WarningCollectorConfig
 {
-    void add(WarningCode code, String warningMessage, AstNode node);
+    private int maxWarnings = Integer.MAX_VALUE;
 
-    List<CoreSqlWarning> getAllWarnings();
+    public WarningCollectorConfig setMaxWarnings(int maxWarnings)
+    {
+        checkArgument(maxWarnings >= 0, "maxWarnings must be >= 0");
+        this.maxWarnings = maxWarnings;
+        return this;
+    }
 
-    void clearWarnings();
+    public int getMaxWarnings()
+    {
+        return maxWarnings;
+    }
 }

--- a/linter/src/test/java/com/facebook/coresql/linter/lint/TestMixedAndOr.java
+++ b/linter/src/test/java/com/facebook/coresql/linter/lint/TestMixedAndOr.java
@@ -11,15 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.coresql.lint;
+package com.facebook.coresql.linter.lint;
 
+import com.facebook.coresql.linter.warning.DefaultWarningCollector;
+import com.facebook.coresql.linter.warning.WarningCollectorConfig;
 import com.facebook.coresql.parser.AstNode;
-import com.facebook.coresql.warning.DefaultWarningCollector;
-import com.facebook.coresql.warning.WarningCollectorConfig;
 import org.testng.annotations.Test;
 
+import static com.facebook.coresql.linter.warning.StandardWarningCode.MIXING_AND_OR_WITHOUT_PARENTHESES;
 import static com.facebook.coresql.parser.ParserHelper.parseStatement;
-import static com.facebook.coresql.warning.StandardWarningCode.MIXING_AND_OR_WITHOUT_PARENTHESES;
 import static org.testng.Assert.assertEquals;
 
 public class TestMixedAndOr

--- a/linter/src/test/java/com/facebook/coresql/linter/warning/TestWarningCollector.java
+++ b/linter/src/test/java/com/facebook/coresql/linter/warning/TestWarningCollector.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.coresql.warning;
+package com.facebook.coresql.linter.warning;
 
 import com.facebook.coresql.parser.AstNode;
 import org.testng.annotations.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -1,22 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airbase</artifactId>
         <version>99</version>
     </parent>
+
     <groupId>com.facebook.presto</groupId>
     <artifactId>presto-coresql</artifactId>
     <version>0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <name>presto-coresql</name>
+    <description>coreSql</description>
+    <url>https://github.com/prestodb/sql</url>
+
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     </properties>
+
     <modules>
         <module>parser</module>
+        <module>linter</module>
     </modules>
+
     <build>
         <plugins>
             <plugin>
@@ -25,6 +34,7 @@
                 <version>0.3</version>
                 <extensions>true</extensions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
@@ -32,6 +42,7 @@
                     <preparationGoals>clean verify -DskipTests</preparationGoals>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -39,6 +50,7 @@
                     <fork>false</fork>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
@@ -46,6 +58,7 @@
                     <excludes>**/generated-sources/**/*</excludes>
                 </configuration>
             </plugin>
+
             <plugin>
                 <!-- <groupId>org.apache.maven.plugins</groupId> -->
                 <artifactId>maven-pmd-plugin</artifactId>
@@ -53,6 +66,7 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
@@ -65,6 +79,7 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
@@ -72,6 +87,7 @@
                     <excludes>**/generated-sources/**/*</excludes>
                 </configuration>
             </plugin>
+
             <!-- Always build a jar with the test classes -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Moved lint and warning code into its own top-level package (i.e. sibling of parser rather than child of parser).